### PR TITLE
move dor-workflow-client to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gemspec
 
 # Development dependencies
 gem 'byebug'
-gem 'dor-workflow-client', '~> 7.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     dor_indexing (1.1.1)
       cocina-models (~> 0.94.0)
+      dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
       solrizer
@@ -205,7 +206,6 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  dor-workflow-client (~> 7.0)
   dor_indexing!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/dor_indexing.gemspec
+++ b/dor_indexing.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'cocina-models', '~> 0.94.0'
+  spec.add_dependency 'dor-workflow-client', '~> 7.0'
   spec.add_dependency 'honeybadger'
   spec.add_dependency 'marc-vocab', '~> 0.3.0'
   spec.add_dependency 'solrizer'


### PR DESCRIPTION
@justinlittman I may be mistaken, but isn't dor-workflow-client a true dependency, not a development dependency?