### PR TITLE
use cocina-models 0.94.1 to fix title building issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     dor_indexing (1.1.1)
-      cocina-models (~> 0.94.0)
+      cocina-models (~> 0.94.1)
       dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
@@ -28,7 +28,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.6)
     byebug (11.1.3)
-    cocina-models (0.94.0)
+    cocina-models (0.94.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)

--- a/dor_indexing.gemspec
+++ b/dor_indexing.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'cocina-models', '~> 0.94.0'
+  spec.add_dependency 'cocina-models', '~> 0.94.1'
   spec.add_dependency 'dor-workflow-client', '~> 7.0'
   spec.add_dependency 'honeybadger'
   spec.add_dependency 'marc-vocab', '~> 0.3.0'

--- a/spec/dor_indexing/indexers/descriptive_metadata_indexer_title_spec.rb
+++ b/spec/dor_indexing/indexers/descriptive_metadata_indexer_title_spec.rb
@@ -445,7 +445,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs title from structuredValue, respecting order of occurrence' do
-        skip 'Naomi is fixing the title reconstruction order'
         expect(doc['sw_display_title_tesim']).to eq 'The title. Vol. 1, Supplement : a subtitle'
       end
     end
@@ -506,7 +505,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs title from structuredValue, respecting order of occurrence' do
-        skip 'Naomi is fixing the title reconstruction order'
         expect(doc['sw_display_title_tesim']).to eq 'Series 1. Title'
       end
     end
@@ -731,7 +729,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses correct punctuation and respects order of occurrence' do
-        skip 'Naomi is fixing the title reconstruction order'
         expect(doc['sw_display_title_tesim']).to eq 'Series 1. A Title'
       end
     end


### PR DESCRIPTION
Addressing my former sins with title parsing.

Any incorrect title fields will be addressed by the rolling (re)indexer, which takes 2-3 weeks.