### PR TITLE
rename: BasicIndexer is new name for DataIndexer

### DIFF
--- a/lib/dor_indexing/builders/document_builder.rb
+++ b/lib/dor_indexing/builders/document_builder.rb
@@ -6,7 +6,7 @@ class DorIndexing
     class DocumentBuilder
       ADMIN_POLICY_INDEXER = DorIndexing::Indexers::CompositeIndexer.new(
         DorIndexing::Indexers::AdministrativeTagIndexer,
-        DorIndexing::Indexers::DataIndexer,
+        DorIndexing::Indexers::BasicIndexer,
         DorIndexing::Indexers::RoleMetadataIndexer,
         DorIndexing::Indexers::DefaultObjectRightsIndexer,
         DorIndexing::Indexers::IdentityMetadataIndexer,
@@ -17,7 +17,7 @@ class DorIndexing
 
       COLLECTION_INDEXER = DorIndexing::Indexers::CompositeIndexer.new(
         DorIndexing::Indexers::AdministrativeTagIndexer,
-        DorIndexing::Indexers::DataIndexer,
+        DorIndexing::Indexers::BasicIndexer,
         DorIndexing::Indexers::RightsMetadataIndexer,
         DorIndexing::Indexers::IdentityMetadataIndexer,
         DorIndexing::Indexers::DescriptiveMetadataIndexer,
@@ -28,7 +28,7 @@ class DorIndexing
 
       ITEM_INDEXER = DorIndexing::Indexers::CompositeIndexer.new(
         DorIndexing::Indexers::AdministrativeTagIndexer,
-        DorIndexing::Indexers::DataIndexer,
+        DorIndexing::Indexers::BasicIndexer,
         DorIndexing::Indexers::RightsMetadataIndexer,
         DorIndexing::Indexers::IdentityMetadataIndexer,
         DorIndexing::Indexers::DescriptiveMetadataIndexer,

--- a/lib/dor_indexing/builders/name_builder.rb
+++ b/lib/dor_indexing/builders/name_builder.rb
@@ -2,7 +2,8 @@
 
 class DorIndexing
   module Builders
-    # Builds the author fields for a solr document
+    # class methods return the name values to go in Solr document fields
+    #   used for both contributors and for topics
     class NameBuilder
       # @param [Symbol] strategy ":first" is the strategy for how to choose a name if primary and display name is not found
       # @return [Array<String>] names

--- a/lib/dor_indexing/indexers/basic_indexer.rb
+++ b/lib/dor_indexing/indexers/basic_indexer.rb
@@ -2,8 +2,8 @@
 
 class DorIndexing
   module Indexers
-    # Indexing provided by ActiveFedora
-    class DataIndexer
+    # Basic indexing for all objects
+    class BasicIndexer
       attr_reader :cocina, :workflow_client
 
       def initialize(cocina:, workflow_client:, **)

--- a/spec/dor_indexing/indexers/basic_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/basic_indexer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe DorIndexing::Indexers::DataIndexer do
+RSpec.describe DorIndexing::Indexers::BasicIndexer do
   let(:cocina) do
     dro = build(
       :dro,


### PR DESCRIPTION
DataIndexer is a bad name.   It's not descriptive of what the class is doing.  "Data" is misleading.  If I were guessing, I would think it was about the structural metadata.

All bow before the new name, the BasicIndexer