### PR TITLE
IdentifiableIndexer: new druid fields, some vacuuming

### DIFF
--- a/spec/dor_indexing/indexers/composite_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/composite_indexer_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe DorIndexing::Indexers::CompositeIndexer do
         'nonhydrus_apo_title_ssim' => ['test admin policy'],
         'apo_title_ssim' => ['test admin policy'],
         'metadata_source_ssim' => ['DOR'],
+        'druid_bare_ssi' => 'mx123ms3333',
+        'druid_prefixed_ssi' => 'druid:mx123ms3333',
         'objectId_tesim' => ['druid:mx123ms3333', 'mx123ms3333'],
         'topic_ssim' => ['word'],
         'topic_tesim' => ['word']

--- a/spec/dor_indexing/indexers/identifiable_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/identifiable_indexer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DorIndexing::Indexers::IdentifiableIndexer do
 
   describe '#identity_metadata_sources' do
     it 'indexes metadata sources' do
-      expect(indexer.identity_metadata_sources).to eq %w[Folio]
+      expect(indexer.send(:identity_metadata_sources)).to eq %w[Folio]
     end
   end
 


### PR DESCRIPTION
Part of sul-dlss/dor_indexing_app/issues/1031.

Use more obvious field names with correct types.  A druid is a string and should not be tokenized.

Also a teensy bit of dusting and vacuuming.