### PR TITLE
remove solrizer gem as it obscures more than it helps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
-      solrizer
       stanford-mods
       zeitwerk
 
@@ -179,10 +178,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    solrizer (4.1.0)
-      activesupport
-      nokogiri
-      xml-simple
     stanford-mods (3.3.9)
       activesupport
       mods (~> 3.0, >= 3.0.4)
@@ -195,8 +190,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    xml-simple (1.1.9)
-      rexml
     zeitwerk (2.6.12)
 
 PLATFORMS

--- a/dor_indexing.gemspec
+++ b/dor_indexing.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dor-workflow-client', '~> 7.0'
   spec.add_dependency 'honeybadger'
   spec.add_dependency 'marc-vocab', '~> 0.3.0'
-  spec.add_dependency 'solrizer'
   spec.add_dependency 'stanford-mods'
   spec.add_dependency 'zeitwerk'
 end

--- a/dor_indexing.gemspec
+++ b/dor_indexing.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'cocina-models', '~> 0.95.0'
   spec.add_dependency 'dor-workflow-client', '~> 7.0'
   spec.add_dependency 'honeybadger'
-  spec.add_dependency 'marc-vocab', '~> 0.3.0'
+  spec.add_dependency 'marc-vocab', '~> 0.3.0' # for marcgac and marccountry
   spec.add_dependency 'stanford-mods'
   spec.add_dependency 'zeitwerk'
 end

--- a/lib/dor_indexing.rb
+++ b/lib/dor_indexing.rb
@@ -3,7 +3,6 @@
 require 'zeitwerk'
 require 'stanford-mods'
 require 'cocina/models'
-require 'solrizer'
 require 'marc/vocab'
 require 'honeybadger'
 

--- a/lib/dor_indexing/indexers/collection_title_indexer.rb
+++ b/lib/dor_indexing/indexers/collection_title_indexer.rb
@@ -11,14 +11,16 @@ class DorIndexing
         @parent_collections = parent_collections
       end
 
-      # @return [Hash] the partial solr document for identifiable concerns
+      # @return [Hash] the partial solr document for collection title concerns
       def to_solr
         {}.tap do |solr_doc|
-          parent_collections.each do |related_obj|
-            coll_title = Cocina::Models::Builders::TitleBuilder.build(related_obj.description.title)
+          parent_collections.each do |collection_obj|
+            coll_title = Cocina::Models::Builders::TitleBuilder.build(collection_obj.description.title)
 
-            # create/append collection_title_tesim and collection_title_ssim
-            ::Solrizer.insert_field(solr_doc, 'collection_title', coll_title, :stored_searchable, :symbol)
+            solr_doc['collection_title_ssim'] ||= []
+            solr_doc['collection_title_ssim'] << coll_title
+            solr_doc['collection_title_tesim'] ||= []
+            solr_doc['collection_title_tesim'] << coll_title
           end
         end
       end

--- a/lib/dor_indexing/indexers/identifiable_indexer.rb
+++ b/lib/dor_indexing/indexers/identifiable_indexer.rb
@@ -56,15 +56,18 @@ class DorIndexing
 
       # @param [Hash] solr_doc
       # @param [String] admin_policy_id
-      def add_apo_titles(solr_doc, admin_policy_id)
+      def add_apo_titles(solr_doc, admin_policy_id) # rubocop:disable Metrics/MethodLength
         row = populate_cache(admin_policy_id)
         title = row['related_obj_title']
         if row['is_from_hydrus']
-          ::Solrizer.insert_field(solr_doc, 'hydrus_apo_title', title, :symbol)
+          solr_doc['hydrus_apo_title_ssim'] ||= []
+          solr_doc['hydrus_apo_title_ssim'] << title
         else
-          ::Solrizer.insert_field(solr_doc, 'nonhydrus_apo_title', title, :symbol)
+          solr_doc['nonhydrus_apo_title_ssim'] ||= []
+          solr_doc['nonhydrus_apo_title_ssim'] << title
         end
-        ::Solrizer.insert_field(solr_doc, 'apo_title', title, :symbol)
+        solr_doc['apo_title_ssim'] ||= []
+        solr_doc['apo_title_ssim'] << title
       end
 
       # populate cache if necessary

--- a/spec/dor_indexing/indexers/collection_title_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/collection_title_indexer_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe DorIndexing::Indexers::CollectionTitleIndexer do
       let(:collections) { [] }
 
       it "doesn't raise an error" do
-        expect(doc[Solrizer.solr_name('collection_title', :symbol)]).to be_nil
-        expect(doc[Solrizer.solr_name('collection_title', :stored_searchable)]).to be_nil
+        expect(doc['collection_title_ssim']).to be_nil
+        expect(doc['collection_title_tesim']).to be_nil
       end
     end
 
@@ -25,8 +25,8 @@ RSpec.describe DorIndexing::Indexers::CollectionTitleIndexer do
       let(:collection) { build(:collection, id: collection_druid, title: 'Collection test object') }
 
       it 'generates collection title fields' do
-        expect(doc[Solrizer.solr_name('collection_title', :symbol)].first).to eq 'Collection test object'
-        expect(doc[Solrizer.solr_name('collection_title', :stored_searchable)].first).to eq 'Collection test object'
+        expect(doc['collection_title_ssim'].first).to eq 'Collection test object'
+        expect(doc['collection_title_tesim'].first).to eq 'Collection test object'
       end
     end
   end

--- a/spec/dor_indexing/indexers/identifiable_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/identifiable_indexer_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe DorIndexing::Indexers::IdentifiableIndexer do
       end
 
       it 'generates apo title fields' do
-        expect(doc[Solrizer.solr_name('apo_title', :symbol)].first).to eq apo_id
-        expect(doc[Solrizer.solr_name('nonhydrus_apo_title', :symbol)].first).to eq apo_id
+        expect(doc['apo_title_ssim'].first).to eq apo_id
+        expect(doc['nonhydrus_apo_title_ssim'].first).to eq apo_id
       end
     end
 
@@ -58,8 +58,8 @@ RSpec.describe DorIndexing::Indexers::IdentifiableIndexer do
       let(:related) { build(:collection, id: mock_rel_druid, admin_policy_id: apo_id, title: 'collection title') }
 
       it 'generates apo title fields' do
-        expect(doc[Solrizer.solr_name('apo_title', :symbol)].first).to eq 'collection title'
-        expect(doc[Solrizer.solr_name('nonhydrus_apo_title', :symbol)].first).to eq 'collection title'
+        expect(doc['apo_title_ssim'].first).to eq 'collection title'
+        expect(doc['nonhydrus_apo_title_ssim'].first).to eq 'collection title'
       end
 
       it 'indexes metadata sources' do

--- a/spec/dor_indexing/indexers/workflow_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/workflow_indexer_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe DorIndexing::Indexers::WorkflowIndexer do
     end
 
     context 'when there are error messages' do
+      let(:wf_error) { solr_doc['wf_error_ssim'] }
       let(:xml) do
         <<-XML
         <?xml version="1.0" encoding="UTF-8"?>
@@ -142,8 +143,6 @@ RSpec.describe DorIndexing::Indexers::WorkflowIndexer do
         XML
       end
 
-      let(:wf_error) { solr_doc[Solrizer.solr_name('wf_error', :symbol)] }
-
       it 'indexes the error messages' do
         expect(wf_error).to eq ['accessionWF:technical-metadata:druid:gv054hp4128 - Item error; caused by 413 Request Entity Too Large:']
       end
@@ -152,6 +151,7 @@ RSpec.describe DorIndexing::Indexers::WorkflowIndexer do
     context 'when the error messages are crazy long' do
       let(:error_length) { 40_000 }
       let(:error) { (0...error_length).map { rand(65..90).chr }.join }
+      let(:wf_error) { solr_doc['wf_error_ssim'] }
       let(:xml) do
         <<-XML
         <?xml version="1.0" encoding="UTF-8"?>
@@ -163,8 +163,6 @@ RSpec.describe DorIndexing::Indexers::WorkflowIndexer do
         </workflow>
         XML
       end
-
-      let(:wf_error) { solr_doc[Solrizer.solr_name('wf_error', :symbol)] }
 
       it "truncates the error messages to below Solr's limit" do
         # 31 is the leader


### PR DESCRIPTION
The tests certainly failed until I got the code right, so I would say this has been well tested.

Making things simpler and more obvious feels like the right direction.

Plus, solrizer became part of ActiveFedora about 5 years ago and has had no maintenance.