### PR TITLE
remove metadata_format_ssim as it is unused in any of our code

### DIFF
--- a/lib/dor_indexing/indexers/descriptive_metadata_indexer.rb
+++ b/lib/dor_indexing/indexers/descriptive_metadata_indexer.rb
@@ -43,8 +43,6 @@ class DorIndexing
           'originInfo_place_placeTerm_tesim' => event_place, # do we want this?
           'sw_pub_date_facet_ssi' => stanford_mods_record.pub_year_int.to_s, # SW Date facet
 
-          'metadata_format_ssim' => 'mods', # no longer used? https://github.com/search?q=org%3Asul-dlss+metadata_format_ssim&type=code
-
           # SW facets plus a friend facet
           'sw_format_ssim' => sw_format, # SW Resource Type facet
           'mods_typeOfResource_ssim' => resource_type, # MODS Resource Type facet

--- a/spec/dor_indexing/indexers/composite_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/composite_indexer_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe DorIndexing::Indexers::CompositeIndexer do
 
     it 'calls each of the provided indexers and combines the results' do
       expect(doc).to eq(
-        'metadata_format_ssim' => 'mods',
         'descriptive_tiv' => 'Test item word',
         'descriptive_teiv' => 'Test item word',
         'descriptive_text_nostem_i' => 'Test item word',

--- a/spec/dor_indexing/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/descriptive_metadata_indexer_spec.rb
@@ -382,7 +382,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
                         'Property in land. blah blah print 10 v. fronts (v. 1-9) ports. 21 cm. Economics 1800-1900 ' \
                         'Economics Europe cats'
       expect(doc).to eq(
-        'metadata_format_ssim' => 'mods',
         'descriptive_tiv' => all_search_text,
         'descriptive_teiv' => all_search_text,
         'descriptive_text_nostem_i' => all_search_text,
@@ -466,7 +465,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
                           'Jews in the Islamic countries'
         # rubocop:disable Style/StringHashKeys
         expect(doc).to eq(
-          'metadata_format_ssim' => 'mods',
           'descriptive_tiv' => all_search_text,
           'descriptive_teiv' => all_search_text,
           'descriptive_text_nostem_i' => all_search_text,


### PR DESCRIPTION
I have github searched (https://github.com/search?q=org%3Asul-dlss+metadata_format_ssim&type=code) and I have "ack"ed and I'm confident this field is not used anywhere.  Let's get rid of it.