### PR TITLE
remove dor_id_tesim as it is unused in any of our code

### DIFF
--- a/lib/dor_indexing/indexers/identity_metadata_indexer.rb
+++ b/lib/dor_indexing/indexers/identity_metadata_indexer.rb
@@ -11,15 +11,13 @@ class DorIndexing
       end
 
       # @return [Hash] the partial solr document for identityMetadata
-      # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
       def to_solr
         return { 'objectType_ssim' => [object_type] } if object_type == 'adminPolicy' || cocina_object.identification.nil?
 
         {
           'objectType_ssim' => [object_type],
-          'dor_id_tesim' => [source_id_value, barcode, folio_instance_hrid, previous_ils_ids].flatten.compact,
-          'identifier_ssim' => prefixed_identifiers,
+          'identifier_ssim' => prefixed_identifiers, # sourceid, barcode, folio_instance_hrid
           'identifier_tesim' => prefixed_identifiers,
           'barcode_id_ssim' => [barcode].compact,
           'source_id_ssi' => source_id,
@@ -28,7 +26,6 @@ class DorIndexing
           'doi_ssim' => [doi].compact
         }
       end
-      # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
 
       private

--- a/spec/dor_indexing/indexers/identity_metadata_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/identity_metadata_indexer_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe DorIndexing::Indexers::IdentityMetadataIndexer do
         expect(doc).to include(
           'barcode_id_ssim' => ['36105049267078'],
           'folio_instance_hrid_ssim' => ['a129483625'],
-          'dor_id_tesim' => %w[STANFORD_342837261527 36105049267078 a129483625 a777],
           'identifier_ssim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
                                 'folio:a129483625'],
           'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
@@ -70,7 +69,6 @@ RSpec.describe DorIndexing::Indexers::IdentityMetadataIndexer do
       it 'has the fields used by argo' do
         expect(doc).to include(
           'barcode_id_ssim' => [],
-          'dor_id_tesim' => ['1234'],
           'identifier_ssim' => ['sul:1234'],
           'identifier_tesim' => ['sul:1234'],
           'objectType_ssim' => ['agreement'],
@@ -107,7 +105,6 @@ RSpec.describe DorIndexing::Indexers::IdentityMetadataIndexer do
         expect(doc).to include(
           'barcode_id_ssim' => [],
           'folio_instance_hrid_ssim' => ['a129483625'],
-          'dor_id_tesim' => %w[STANFORD_342837261527 a129483625],
           'identifier_ssim' => ['google:STANFORD_342837261527', 'folio:a129483625'],
           'identifier_tesim' => ['google:STANFORD_342837261527', 'folio:a129483625'],
           'objectType_ssim' => ['collection'],


### PR DESCRIPTION
I have github searched (https://github.com/search?q=org%3Asul-dlss+dor_id_tesim&type=code) and I have "ack"ed all my locally cloned repos and I'm confident this field is not used anywhere. Let's get rid of it.