### PR TITLE
workflow indexer classes get better comments and names

### DIFF
--- a/lib/dor_indexing/indexers/workflow_indexer.rb
+++ b/lib/dor_indexing/indexers/workflow_indexer.rb
@@ -2,7 +2,7 @@
 
 class DorIndexing
   module Indexers
-    # Indexes the objects position in workflows
+    # Indexes the object's state for each process in a single workflow
     class WorkflowIndexer
       # @param [Workflow::Response::Workflow] workflow the workflow document to index
       def initialize(workflow:, workflow_client:)
@@ -10,14 +10,14 @@ class DorIndexing
         @workflow_client = workflow_client
       end
 
-      # @return [Hash] the partial solr document for the workflow document
+      # @return [Hash] the partial solr document for all the workflow processes
       def to_solr
         WorkflowSolrDocument.new do |solr_doc|
           solr_doc.name = workflow_name
 
           errors = 0 # The error count is used by the Report class in Argo
           processes.each do |process|
-            ProcessIndexer.new(solr_doc:, workflow_name:, process:).to_solr
+            WorkflowProcessIndexer.new(solr_doc:, workflow_name:, process:).to_solr
             errors += 1 if process.status == 'error'
           end
           solr_doc.status = [workflow_name, workflow_status, errors].join('|')

--- a/lib/dor_indexing/indexers/workflow_process_indexer.rb
+++ b/lib/dor_indexing/indexers/workflow_process_indexer.rb
@@ -2,8 +2,8 @@
 
 class DorIndexing
   module Indexers
-    # Indexes the process for a workflow
-    class ProcessIndexer
+    # Creates solr doc fields (and values) for a process for a workflow (which is for an object)
+    class WorkflowProcessIndexer
       ERROR_OMISSION = '... (continued)'
       private_constant :ERROR_OMISSION
 
@@ -13,14 +13,14 @@ class DorIndexing
 
       # @param [WorkflowSolrDocument] solr_doc
       # @param [String] workflow_name
-      # @param [Dor::Workflow::Response::Process] process
+      # @param [Dor::Workflow::Response::Process] process containing data for a process in a workflow for an object
       def initialize(solr_doc:, workflow_name:, process:)
         @solr_doc = solr_doc
         @workflow_name = workflow_name
         @process = process
       end
 
-      # @return [Hash] the partial solr document for the workflow document
+      # @return [Hash] the partial solr document for a single workflow process
       # rubocop:disable Metrics/AbcSize
       def to_solr
         return unless status

--- a/lib/dor_indexing/indexers/workflows_indexer.rb
+++ b/lib/dor_indexing/indexers/workflows_indexer.rb
@@ -2,7 +2,7 @@
 
 class DorIndexing
   module Indexers
-    # Indexes the objects position in workflows
+    # Indexes the object's state in the most recent execution of every one of its workflows
     class WorkflowsIndexer
       attr_reader :id
 
@@ -11,7 +11,7 @@ class DorIndexing
         @workflow_client = workflow_client
       end
 
-      # @return [Hash] the partial solr document for workflow concerns
+      # @return [Hash] the partial solr document for workflows concerns
       def to_solr
         WorkflowSolrDocument.new do |combined_doc|
           workflows.each do |wf|
@@ -30,7 +30,6 @@ class DorIndexing
         all_workflows.workflows
       end
 
-      # TODO: remove Dor::Workflow::Document
       # @return [Workflow::Response::Workflows]
       def all_workflows
         @all_workflows ||= workflow_client.workflow_routes.all_workflows pid: id


### PR DESCRIPTION
These are all changes to help the drunken coder.

The TODO comment in workflows_indexer appears to be vestigial:

https://github.com/search?q=org%3Asul-dlss%20Dor%3A%3AWorkflow%3A%3ADocument&type=code

See also sul-dlss/argo/pull/4320
