### PR TITLE
Prefer requiring dependencies to relying on transitive dependencies

### DIFF
--- a/dor_indexing.gemspec
+++ b/dor_indexing.gemspec
@@ -31,11 +31,11 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport' # for blank? method
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'cocina-models', '~> 0.95.0'
   spec.add_dependency 'dor-workflow-client', '~> 7.0'
   spec.add_dependency 'honeybadger'
-  spec.add_dependency 'marc-vocab', '~> 0.3.0' # for marcgac and marccountry
+  spec.add_dependency 'marc-vocab', '~> 0.3.0'
   spec.add_dependency 'stanford-mods'
   spec.add_dependency 'zeitwerk'
 end

--- a/lib/dor_indexing.rb
+++ b/lib/dor_indexing.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require 'zeitwerk'
-require 'stanford-mods'
-require 'cocina/models'
-require 'marc/vocab'
-require 'honeybadger'
 
 Zeitwerk::Loader.for_gem.setup
+
+# Zeitwerk doesn't auto-load these dependencies
+require 'active_support'
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/enumerable'
+require 'active_support/core_ext/string'
+require 'cocina/models'
+require 'honeybadger'
+require 'marc/vocab'
 
 # Builds solr documents for indexing.
 class DorIndexing


### PR DESCRIPTION
Follows #29

This commit adds a few small changes so the gem is more explicit about its own dependencies:

* Add missing `require` statements for the parts of ActiveSupport the gem needs
* Lean on zeitwerk to do its job (no need to explicitly require `stanford-mods`) and load zeitwerk-incompatible dependencies afterward
* Remove comments from gemspec (look at `require`s to see what parts of ActiveSupport the gem depends on)

Prior to this change, the gem only had access to ActiveSupport functionality by virtue of other dependencies using ActiveSupport, e.g., `cocina-models` and `stanford-mods`.
