### PR TITLE
objectId_tesim removed; it was replaced by druid_prefixed_ssi and druid_bare_ssi

### DIFF
--- a/lib/dor_indexing/indexers/identifiable_indexer.rb
+++ b/lib/dor_indexing/indexers/identifiable_indexer.rb
@@ -18,14 +18,13 @@ class DorIndexing
       @@apo_hash = {} # rubocop:disable Style/ClassVars
 
       # @return [Hash] the partial solr document for identifiable concerns
-      def to_solr # rubocop:disable Metrics/AbcSize
+      def to_solr
         {}.tap do |solr_doc|
           add_apo_titles(solr_doc, cocina.administrative.hasAdminPolicy)
 
           solr_doc['metadata_source_ssim'] = identity_metadata_sources unless cocina.is_a? Cocina::Models::AdminPolicyWithMetadata
           solr_doc['druid_prefixed_ssi'] = cocina.externalIdentifier
           solr_doc['druid_bare_ssi'] = cocina.externalIdentifier.delete_prefix('druid:')
-          solr_doc['objectId_tesim'] = [cocina.externalIdentifier, cocina.externalIdentifier.delete_prefix('druid:')] # DEPRECATED
         end
       end
 

--- a/spec/dor_indexing/indexers/composite_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/composite_indexer_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe DorIndexing::Indexers::CompositeIndexer do
         'metadata_source_ssim' => ['DOR'],
         'druid_bare_ssi' => 'mx123ms3333',
         'druid_prefixed_ssi' => 'druid:mx123ms3333',
-        'objectId_tesim' => ['druid:mx123ms3333', 'mx123ms3333'],
         'topic_ssim' => ['word'],
         'topic_tesim' => ['word']
       )


### PR DESCRIPTION
Part of sul-dlss/dor_indexing_app/issues/1031

All consumers of objectId_tesim have been removed.