### PR TITLE
stop indexing to sw_display_title_tesim as it is no longer used

### DIFF
--- a/lib/dor_indexing/indexers/descriptive_metadata_indexer.rb
+++ b/lib/dor_indexing/indexers/descriptive_metadata_indexer.rb
@@ -25,7 +25,6 @@ class DorIndexing
           'full_title_tenim' => full_title, # for searching; 1 more field type is copyField in solr schema.xml
           'additional_titles_tenim' => additional_titles, # for searching; 1 more field type is copyField in solr schema.xml
           'display_title_ss' => display_title, # for display in Argo
-          'sw_display_title_tesim' => display_title, # for display in Argo DEPRECATED in favor of display_title_ss
 
           # contributor
           'author_text_nostem_im' => author_primary, # primary author tokenized but not stemmed

--- a/spec/dor_indexing/indexers/composite_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/composite_indexer_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe DorIndexing::Indexers::CompositeIndexer do
         'main_title_tenim' => ['Test item'],
         'full_title_tenim' => ['Test item'],
         'display_title_ss' => 'Test item',
-        'sw_display_title_tesim' => 'Test item',
         'nonhydrus_apo_title_ssim' => ['test admin policy'],
         'apo_title_ssim' => ['test admin policy'],
         'metadata_source_ssim' => ['DOR'],

--- a/spec/dor_indexing/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/descriptive_metadata_indexer_spec.rb
@@ -398,7 +398,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
         'full_title_tenim' => ['The complete works of Henry George'],
         # 'additional_titles_tenim' => '', # not populated by the example; see indexer_spec instead
         'display_title_ss' => 'The complete works of Henry George',
-        'sw_display_title_tesim' => 'The complete works of Henry George',
         # 'originInfo_date_created_tesim' => '', # not populated by the example; see indexer_spec instead
         'originInfo_publisher_tesim' => 'Doubleday, Page',
         'topic_ssim' => %w[Economics cats],
@@ -472,8 +471,7 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
           'full_title_tenim' => ['Toldot ha-Yehudim be-artsot ha-Islam ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19',
                                  'תולדות היהודים בארצות האיסלאם העת החדשה עד אמצע המאה ה־19'],
           'additional_titles_tenim' => ['History of the Jews in the Islamic countries'],
-          'display_title_ss' => 'Toldot ha-Yehudim be-artsot ha-Islam : ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19',
-          'sw_display_title_tesim' => 'Toldot ha-Yehudim be-artsot ha-Islam : ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19'
+          'display_title_ss' => 'Toldot ha-Yehudim be-artsot ha-Islam : ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19'
         )
         # rubocop:enable Style/StringHashKeys
       end

--- a/spec/dor_indexing/indexers/descriptive_metadata_indexer_title_spec.rb
+++ b/spec/dor_indexing/indexers/descriptive_metadata_indexer_title_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
     # 'full_title_tenim' => full_title, # for searching; 1 more field type is copyField in solr schema.xml
     # 'additional_titles_tenim' => additional_titles, # for searching; 1 more field type is copyField in solr schema.xml
     # 'display_title_ss' => display_title, # for display in Argo
-    # 'sw_display_title_tesim' => DEPRECATED; will be replaced by display_title_ss
 
     context 'with multiple typed and untyped simple title values, one status primary' do
       let(:titles) do
@@ -50,10 +49,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
 
       it 'display_title_ss is value with status primary' do
         expect(doc['display_title_ss']).to eq 'Primary Title'
-      end
-
-      it 'sw_display_title_tesim is value with status primary' do
-        expect(doc['sw_display_title_tesim']).to eq 'Primary Title'
       end
     end
 
@@ -91,10 +86,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
       it 'display_title_ss is first value' do
         expect(doc['display_title_ss']).to eq 'First'
       end
-
-      it 'sw_display_title_tesim is first value' do
-        expect(doc['sw_display_title_tesim']).to eq 'First'
-      end
     end
 
     context 'with space/punctuation/space ending simple value' do
@@ -120,10 +111,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
 
       it 'display_title_ss is value without trailing punctuation or spaces' do
         expect(doc['display_title_ss']).to eq 'Title'
-      end
-
-      it 'sw_display_title_tesim is value without trailing punctuation or spaces' do
-        expect(doc['sw_display_title_tesim']).to eq 'Title'
       end
     end
 
@@ -171,10 +158,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
 
       it 'display_title_ss is rebuilt structuredValue with punctuation' do
         expect(doc['display_title_ss']).to eq 'A title : a subtitle. Vol. 1, Supplement'
-      end
-
-      it 'sw_display_title_tesim is rebuilt structuredValue with punctuation' do
-        expect(doc['sw_display_title_tesim']).to eq 'A title : a subtitle. Vol. 1, Supplement'
       end
     end
 
@@ -224,10 +207,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
       it 'display_title_ss is rebuilt structured value with punctuation' do
         expect(doc['display_title_ss']).to eq 'The title. Vol. 1, Supplement : a subtitle'
       end
-
-      it 'sw_display_title_tesim is rebuilt structured value with punctuation' do
-        expect(doc['sw_display_title_tesim']).to eq 'The title. Vol. 1, Supplement : a subtitle'
-      end
     end
 
     context 'with structuredValue with nonsorting character count' do
@@ -271,10 +250,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
       it 'display_title_ss includes nonsorting chars without extra space' do
         expect(doc['display_title_ss']).to eq 'L\'autre title'
       end
-
-      it 'sw_display_title_tesim includes nonsorting chars without extra space' do
-        expect(doc['sw_display_title_tesim']).to eq 'L\'autre title'
-      end
     end
 
     context 'with structuredValue with nonsorting characters not first' do
@@ -313,10 +288,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
 
       it 'display_title_ss is reconstructed value in occurrence order with punctuation added' do
         expect(doc['display_title_ss']).to eq 'Series 1. A Title'
-      end
-
-      it 'sw_display_title_tesim is reconstructed value in occurrence order with punctuation added' do
-        expect(doc['sw_display_title_tesim']).to eq 'Series 1. A Title'
       end
     end
 
@@ -365,10 +336,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
       it 'display_title_ss is value of the only title without associated name note' do
         expect(doc['display_title_ss']).to eq 'Title'
       end
-
-      it 'sw_display_title_tesim is value of the only title without associated name note' do
-        expect(doc['sw_display_title_tesim']).to eq 'Title'
-      end
     end
 
     context 'with structuredValue containing punctuation/space in individual values' do
@@ -406,10 +373,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
       it 'display_title_ss is reconstructed value with adjusted punctuation' do
         expect(doc['display_title_ss']).to eq 'Title : subtitle'
       end
-
-      it 'sw_display_title_tesim is reconstructed value with adjusted punctuation' do
-        expect(doc['sw_display_title_tesim']).to eq 'Title : subtitle'
-      end
     end
 
     context 'with parallelValue with primary on (whole) parallelValue' do
@@ -443,10 +406,6 @@ RSpec.describe DorIndexing::Indexers::DescriptiveMetadataIndexer do
 
       it 'display_title_ss is first parallel value' do
         expect(doc['display_title_ss']).to eq 'Title 1'
-      end
-
-      it 'sw_display_title_tesim is first parallel value' do
-        expect(doc['sw_display_title_tesim']).to eq 'Title 1'
       end
     end
   end


### PR DESCRIPTION
We are using different title fields in the Argo solr index now;  this field can now be removed.