### PR TITLE
Include collection release tags from parent collections, not self.

### DIFF
--- a/lib/dor_indexing/indexers/releasable_indexer.rb
+++ b/lib/dor_indexing/indexers/releasable_indexer.rb
@@ -53,7 +53,7 @@ class DorIndexing
         parent_collections.each_with_object({}) do |collection, result|
           release_tags_finder
             .call(collection.externalIdentifier)
-            .select { |tag| tag.what == 'self' }
+            .select { |tag| tag.what == 'collection' }
             .group_by(&:to).map do |project, releases_for_project|
               result[project] = releases_for_project.max_by(&:date)
             end

--- a/spec/dor_indexing/indexers/releasable_indexer_spec.rb
+++ b/spec/dor_indexing/indexers/releasable_indexer_spec.rb
@@ -99,11 +99,24 @@ RSpec.describe DorIndexing::Indexers::ReleasableIndexer do
         end
       end
 
-      context 'when the parent collection has releaseTags' do
+      context 'when the parent collection has self releaseTags' do
         let(:release_tags) { [] }
         let(:collection_release_tags) do
           [
             Cocina::Models::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00', what: 'self')
+          ]
+        end
+
+        it 'indexes release tags' do
+          expect(doc).to be_empty
+        end
+      end
+
+      context 'when the parent collection has collection releaseTags' do
+        let(:release_tags) { [] }
+        let(:collection_release_tags) do
+          [
+            Cocina::Models::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00', what: 'collection')
           ]
         end
 


### PR DESCRIPTION
See https://stanfordlib.slack.com/archives/C056A6GDE7Q/p1712250239068669